### PR TITLE
Replace online patching with local binary patching

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -342,22 +342,22 @@ ipcMain.on("rpc:enable", (_, enable) => {
 
 ipcMain.handle(
   "online-patch:check",
-  async (_, gameDir: string, version: GameVersion) => {
-    return await checkOnlinePatchNeeded(gameDir, version);
+  async (_, gameDir: string, version: GameVersion, authServerUrl?: string | null) => {
+    return await checkOnlinePatchNeeded(gameDir, version, authServerUrl);
   },
 );
 
 ipcMain.handle(
   "online-patch:state",
-  async (_, gameDir: string, version: GameVersion) => {
-    return getOnlinePatchState(gameDir, version);
+  async (_, gameDir: string, version: GameVersion, authServerUrl?: string | null) => {
+    return getOnlinePatchState(gameDir, version, authServerUrl);
   },
 );
 
 ipcMain.handle(
   "online-patch:health",
-  async (_, gameDir: string, version: GameVersion) => {
-    return await getOnlinePatchHealth(gameDir, version);
+  async (_, gameDir: string, version: GameVersion, authServerUrl?: string | null) => {
+    return await getOnlinePatchHealth(gameDir, version, authServerUrl);
   },
 );
 
@@ -534,6 +534,7 @@ ipcMain.on(
     version: GameVersion,
     username: string,
     customUUID?: string | null,
+    authServerUrl?: string | null,
   ) => {
     const win = BrowserWindow.fromWebContents(e.sender);
     if (win) {
@@ -543,7 +544,7 @@ ipcMain.on(
         backgroundTimeout = null;
       }
 
-      launchGame(gameDir, version, username, win, 0, customUUID ?? null, {
+      launchGame(gameDir, version, username, win, 0, customUUID ?? null, authServerUrl ?? null, {
         onGameSpawned: () => {
           logger.info(`Game spawned: ${version.type} ${version.build_name}`);
           isGameRunning = true;
@@ -584,7 +585,7 @@ ipcMain.on(
 
 ipcMain.on(
   "online-patch:enable",
-  async (e, gameDir: string, version: GameVersion) => {
+  async (e, gameDir: string, version: GameVersion, authServerUrl?: string | null) => {
     const win = BrowserWindow.fromWebContents(e.sender);
     if (!win) return;
 
@@ -610,6 +611,7 @@ ipcMain.on(
         version,
         win,
         "online-patch-progress",
+        authServerUrl,
       );
       win.webContents.send("online-patch-finished", result);
     } catch (err) {
@@ -623,7 +625,7 @@ ipcMain.on(
 
 ipcMain.on(
   "online-patch:disable",
-  async (e, gameDir: string, version: GameVersion) => {
+  async (e, gameDir: string, version: GameVersion, authServerUrl?: string | null) => {
     const win = BrowserWindow.fromWebContents(e.sender);
     if (!win) return;
 
@@ -648,6 +650,7 @@ ipcMain.on(
         version,
         win,
         "online-unpatch-progress",
+        authServerUrl,
       );
       win.webContents.send("online-unpatch-finished", result);
     } catch (err) {
@@ -661,7 +664,7 @@ ipcMain.on(
 
 ipcMain.on(
   "online-patch:fix-client",
-  async (e, gameDir: string, version: GameVersion) => {
+  async (e, gameDir: string, version: GameVersion, authServerUrl?: string | null) => {
     const win = BrowserWindow.fromWebContents(e.sender);
     if (!win) return;
 
@@ -686,6 +689,7 @@ ipcMain.on(
         version,
         win,
         "online-unpatch-progress",
+        authServerUrl,
       );
       win.webContents.send("online-unpatch-finished", result);
     } catch (err) {

--- a/electron/utils/game/binaryPatcher.ts
+++ b/electron/utils/game/binaryPatcher.ts
@@ -1,0 +1,551 @@
+import fs from "fs";
+import https from "https";
+import path from "path";
+import { BrowserWindow } from "electron";
+import AdmZip from "adm-zip";
+import {
+  migrateLegacyChannelInstallIfNeeded,
+  resolveClientPath,
+  resolveExistingInstallDir,
+  resolveServerPath,
+} from "./paths";
+import { GameVersion } from "./types";
+
+// Domain configuration for Patch
+const ORIGINAL_DOMAIN = "hytale.com";
+const DEFAULT_AUTH_DOMAIN = "auth.sanasol.ws";
+const MIN_DOMAIN_LENGTH = 4;
+const MAX_DOMAIN_LENGTH = 16;
+
+// Backup extension for original files
+export const BACKUP_EXTENSION = ".original";
+const PATCH_FLAG_FILENAME = ".butter_patched_v2";
+
+// --- Sanasol Patcher Logic (adapted to TypeScript) ---
+
+type DomainStrategy = {
+  mode: "direct" | "split";
+  mainDomain: string;
+  subdomainPrefix: string;
+  description: string;
+};
+
+type PatchResult = {
+  success: boolean;
+  patchCount: number;
+  alreadyPatched?: boolean;
+  warning?: string;
+  error?: string;
+};
+
+type PatchProgress = (message: string, percent: number | null) => void;
+
+/**
+ * Calculate the domain patching strategy based on length.
+ */
+const getDomainStrategy = (domain: string): DomainStrategy => {
+  if (domain.length <= 10) {
+    return {
+      mode: "direct",
+      mainDomain: domain,
+      subdomainPrefix: "",
+      description: `Direct replacement: hytale.com -> ${domain}`,
+    };
+  } else {
+    const prefix = domain.slice(0, 6);
+    const suffix = domain.slice(6);
+    return {
+      mode: "split",
+      mainDomain: suffix,
+      subdomainPrefix: prefix,
+      description: `Split mode: subdomain prefix="${prefix}", main domain="${suffix}"`,
+    };
+  }
+};
+
+/**
+ * Convert a string to the length-prefixed byte format used by the client.
+ */
+const stringToLengthPrefixed = (str: string): Buffer => {
+  const length = str.length;
+  // Format: [length byte] [00 00 00 padding] [char1] [00] [char2] [00] ...
+  const result = Buffer.alloc(4 + length + (length > 0 ? length - 1 : 0));
+
+  result[0] = length;
+  result[1] = 0x00;
+  result[2] = 0x00;
+  result[3] = 0x00;
+
+  let pos = 4;
+  for (let i = 0; i < length; i++) {
+    result[pos++] = str.charCodeAt(i);
+    if (i < length - 1) {
+      result[pos++] = 0x00;
+    }
+  }
+  return result;
+};
+
+/**
+ * Convert a string to UTF-8 bytes.
+ */
+const stringToUtf8 = (str: string): Buffer => {
+  return Buffer.from(str, "utf8");
+};
+
+/**
+ * Find all occurrences of a pattern in a buffer.
+ */
+const findAllOccurrences = (buffer: Buffer, pattern: Buffer): number[] => {
+  const positions: number[] = [];
+  let pos = 0;
+  while (pos < buffer.length) {
+    const index = buffer.indexOf(pattern, pos);
+    if (index === -1) break;
+    positions.push(index);
+    pos = index + 1;
+  }
+  return positions;
+};
+
+/**
+ * Replace bytes in buffer; only overwrites the length of new bytes.
+ */
+const replaceBytes = (
+  buffer: Buffer,
+  oldBytes: Buffer,
+  newBytes: Buffer,
+): { buffer: Buffer; count: number } => {
+  let count = 0;
+  const result = Buffer.from(buffer);
+
+  if (newBytes.length > oldBytes.length) {
+    console.warn(
+      `[Patcher] New pattern (len ${newBytes.length}) longer than old (len ${oldBytes.length}), skipping replacement.`
+    );
+    return { buffer: result, count: 0 };
+  }
+
+  const positions = findAllOccurrences(result, oldBytes);
+  for (const pos of positions) {
+    newBytes.copy(result, pos);
+    count++;
+  }
+
+  return { buffer: result, count };
+};
+
+/**
+ * The main patching method for the client binary.
+ */
+const applyClientPatches = (
+  data: Buffer,
+  domain: string,
+  protocol = "https://",
+): { buffer: Buffer; count: number } => {
+  let result = Buffer.from(data);
+  let totalCount = 0;
+  const strategy = getDomainStrategy(domain);
+
+  console.log(`[Patcher] Client Strategy: ${strategy.description}`);
+
+  // 1. Patch Sentry/telemetry URL
+  const oldSentry =
+    "https://ca900df42fcf57d4dd8401a86ddd7da2@sentry.hytale.com/2";
+  const newSentry = `${protocol}t@${domain}/2`;
+  const sentryResult = replaceBytes(
+    result,
+    stringToLengthPrefixed(oldSentry),
+    stringToLengthPrefixed(newSentry),
+  );
+  result = sentryResult.buffer;
+  if (sentryResult.count > 0) totalCount += sentryResult.count;
+
+  // 2. Patch main domain (hytale.com -> mainDomain)
+  const domainResult = replaceBytes(
+    result,
+    stringToLengthPrefixed(ORIGINAL_DOMAIN),
+    stringToLengthPrefixed(strategy.mainDomain),
+  );
+  result = domainResult.buffer;
+  if (domainResult.count > 0) totalCount += domainResult.count;
+
+  // 3. Patch subdomain prefixes
+  const subdomains = [
+    "https://tools.",
+    "https://sessions.",
+    "https://account-data.",
+    "https://telemetry.",
+  ];
+  const newSubdomainPrefix = protocol + strategy.subdomainPrefix;
+
+  for (const sub of subdomains) {
+    const subResult = replaceBytes(
+      result,
+      stringToLengthPrefixed(sub),
+      stringToLengthPrefixed(newSubdomainPrefix),
+    );
+    result = subResult.buffer;
+    if (subResult.count > 0) totalCount += subResult.count;
+  }
+
+  // 4. Patch Discord URL
+  const oldDiscord = ".gg/hytale";
+  const newDiscord = ".gg/MHkEjepMQ7";
+  const discordResult = replaceBytes(
+    result,
+    stringToLengthPrefixed(oldDiscord),
+    stringToLengthPrefixed(newDiscord),
+  );
+  result = discordResult.buffer;
+  if (discordResult.count > 0) totalCount += discordResult.count;
+
+  return { buffer: result, count: totalCount };
+};
+
+/**
+ * Create a backup of the original file if it doesn't exist.
+ */
+const createBackup = (filePath: string): boolean => {
+  const backupPath = filePath + BACKUP_EXTENSION;
+  if (!fs.existsSync(backupPath)) {
+    try {
+      fs.copyFileSync(filePath, backupPath);
+      console.log(`[Patcher] Created backup: ${backupPath}`);
+      return true;
+    } catch (error) {
+      console.error(`[Patcher] Failed to create backup: ${error}`);
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * Restore original file from backup.
+ */
+const restoreFromBackup = (filePath: string): boolean => {
+  const backupPath = filePath + BACKUP_EXTENSION;
+  if (fs.existsSync(backupPath)) {
+    try {
+      fs.copyFileSync(backupPath, filePath);
+      fs.unlinkSync(filePath + PATCH_FLAG_FILENAME); // Also remove patch flag
+      console.log(`[Patcher] Restored from backup: ${filePath}`);
+      return true;
+    } catch (error) {
+      console.error(`[Patcher] Failed to restore from backup: ${error}`);
+      return false;
+    }
+  }
+  return false;
+};
+
+/**
+ * Mark a file as patched.
+ */
+const markAsPatched = (filePath: string, targetDomain: string) => {
+  const flagFile = filePath + PATCH_FLAG_FILENAME;
+  const flagData = {
+    patchedAt: new Date().toISOString(),
+    targetDomain,
+  };
+  fs.writeFileSync(flagFile, JSON.stringify(flagData, null, 2));
+};
+
+/**
+ * Check if a file is already patched for the target domain.
+ */
+export const isFilePatched = (filePath: string, targetDomain: string): boolean => {
+  const flagFile = filePath + PATCH_FLAG_FILENAME;
+  if (fs.existsSync(flagFile)) {
+    try {
+      const flagData = JSON.parse(fs.readFileSync(flagFile, "utf8"));
+      if (flagData.targetDomain === targetDomain) {
+        return true;
+      }
+    } catch {
+      // Corrupt flag file, will re-patch.
+    }
+  }
+  return false;
+};
+
+/**
+ * Patches the client binary (HytaleClient.exe)
+ */
+const patchClientFile = (
+  filePath: string,
+  targetDomain: string,
+): PatchResult => {
+  try {
+    console.log("[Patcher] Reading client binary...");
+    const data = fs.readFileSync(filePath);
+
+    console.log("[Patcher] Applying client domain patches...");
+    const { buffer: patchedData, count } = applyClientPatches(data, targetDomain);
+
+    if (count === 0) {
+      return {
+        success: true,
+        patchCount: 0,
+        warning: "No occurrences found to patch in client.",
+      };
+    }
+
+    console.log("[Patcher] Writing patched client binary...");
+    fs.writeFileSync(filePath, patchedData);
+    markAsPatched(filePath, targetDomain);
+
+    return { success: true, patchCount: count };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(`[Patcher] Error patching client: ${errorMessage}`);
+    return { success: false, patchCount: 0, error: errorMessage };
+  }
+};
+
+/**
+ * Patches the server JAR by downloading a pre-patched version.
+ */
+const patchServer = async (
+  filePath: string,
+  targetDomain: string,
+  progressCallback?: PatchProgress,
+): Promise<PatchResult> => {
+  console.log("[Patcher] Server Patcher: Using pre-patched JAR download method.");
+
+  const PRE_PATCHED_URL = "https://pub-027b315ece074e2e891002ca38384792.r2.dev/HytaleServer.jar";
+
+  try {
+    progressCallback?.("Downloading patched server...", 70);
+    await new Promise<void>((resolve, reject) => {
+      const request = https.get(PRE_PATCHED_URL, (response) => {
+        if (response.statusCode === 301 || response.statusCode === 302) {
+          // Follow redirect
+          https.get(response.headers.location!, (redirectResponse) => {
+            if (redirectResponse.statusCode !== 200) {
+              reject(new Error(`Failed to download: HTTP ${redirectResponse.statusCode}`));
+              return;
+            }
+            const file = fs.createWriteStream(filePath);
+            redirectResponse.pipe(file);
+            file.on("finish", () => {
+              file.close();
+              resolve();
+            });
+          }).on("error", reject);
+        } else if (response.statusCode === 200) {
+          const file = fs.createWriteStream(filePath);
+          response.pipe(file);
+          file.on("finish", () => {
+            file.close();
+            resolve();
+          });
+        } else {
+          reject(new Error(`Failed to download: HTTP ${response.statusCode}`));
+        }
+      });
+      request.on("error", (err) => {
+        fs.unlink(filePath, () => {}); // Best-effort cleanup
+        reject(err);
+      });
+    });
+
+    console.log("[Patcher] Pre-patched server downloaded successfully.");
+    markAsPatched(filePath, targetDomain);
+    progressCallback?.("Server patched.", 95);
+    return { success: true, patchCount: 1 };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(`[Patcher] Error downloading pre-patched server: ${errorMessage}`);
+    // Restore backup on failure
+    restoreFromBackup(filePath);
+    return { success: false, patchCount: 0, error: errorMessage };
+  }
+};
+
+// --- Butter-Launcher Integration ---
+
+const getClientPath = (gameDir: string, version: GameVersion): string | null => {
+  migrateLegacyChannelInstallIfNeeded(gameDir, version.type);
+  const installDir = resolveExistingInstallDir(gameDir, version);
+  return installDir ? resolveClientPath(installDir) : null;
+};
+
+const getServerPath = (gameDir: string, version: GameVersion): string | null => {
+  migrateLegacyChannelInstallIfNeeded(gameDir, version.type);
+  const installDir = resolveExistingInstallDir(gameDir, version);
+  return installDir ? resolveServerPath(installDir) : null;
+};
+
+/**
+ * Validates the target domain length.
+ */
+const getValidDomain = (domain: string): string => {
+    if (domain.length < MIN_DOMAIN_LENGTH || domain.length > MAX_DOMAIN_LENGTH) {
+        throw new Error(`[Patcher] Domain "${domain}" is not between ${MIN_DOMAIN_LENGTH} and ${MAX_DOMAIN_LENGTH} chars.`);
+    }
+    return domain;
+};
+
+export const ensureClientPatched = async (
+  gameDir: string,
+  version: GameVersion,
+  progressCallback?: PatchProgress,
+  targetDomain?: string,
+): Promise<{
+  success: boolean;
+  patchCount: number;
+  client?: PatchResult;
+  server?: PatchResult;
+  error?: string;
+}> => {
+  const domain = getValidDomain(targetDomain || DEFAULT_AUTH_DOMAIN);
+  const results = { success: false, patchCount: 0, client: undefined, server: undefined };
+
+  // 1. Patch Client
+  const clientPath = getClientPath(gameDir, version);
+  if (clientPath && fs.existsSync(clientPath)) {
+    progressCallback?.("Patching client...", 10);
+    if (isFilePatched(clientPath, domain)) {
+      console.log(`[Patcher] Client already patched for ${domain}`);
+      results.client = { success: true, patchCount: 0, alreadyPatched: true };
+    } else {
+      createBackup(clientPath);
+      results.client = patchClientFile(clientPath, domain);
+    }
+  } else {
+    results.client = {
+      success: false,
+      patchCount: 0,
+      error: "Client not found",
+    };
+  }
+
+  // 2. Patch Server
+  const serverPath = getServerPath(gameDir, version);
+  if (serverPath && fs.existsSync(serverPath)) {
+    progressCallback?.("Patching server...", 60);
+    if (isFilePatched(serverPath, domain)) {
+      console.log(`[Patcher] Server already patched for ${domain}`);
+      results.server = { success: true, patchCount: 0, alreadyPatched: true };
+    } else {
+      createBackup(serverPath);
+      results.server = await patchServer(serverPath, domain, progressCallback);
+    }
+  } else {
+    results.server = {
+      success: false,
+      patchCount: 0,
+      error: "Server not found",
+    };
+  }
+
+  // 3. Finalize
+  const clientOk = results.client?.success ?? false;
+  const serverOk = results.server?.success ?? false;
+  results.success = clientOk || serverOk; // Success if at least one patched
+  results.patchCount =
+    (results.client?.patchCount ?? 0) + (results.server?.patchCount ?? 0);
+
+  if (!results.success) {
+    results.error = [
+      results.client?.error ? `Client: ${results.client.error}` : null,
+      results.server?.error ? `Server: ${results.server.error}` : null,
+    ]
+      .filter(Boolean)
+      .join("; ");
+  }
+
+  progressCallback?.("Patching complete", 100);
+  return results;
+};
+
+export const restoreOriginals = async (
+  gameDir: string,
+  version: GameVersion,
+  progressCallback?: PatchProgress
+): Promise<{ success: boolean; clientRestored: boolean; serverRestored: boolean }> => {
+  let clientRestored = false;
+  let serverRestored = false;
+
+  const clientPath = getClientPath(gameDir, version);
+  if (clientPath) {
+    progressCallback?.("Restoring original client...", 25);
+    clientRestored = restoreFromBackup(clientPath);
+  }
+
+  const serverPath = getServerPath(gameDir, version);
+  if (serverPath) {
+    progressCallback?.("Restoring original server...", 75);
+    serverRestored = restoreFromBackup(serverPath);
+  }
+
+  progressCallback?.("Restore complete", 100);
+  return {
+    success: clientRestored || serverRestored,
+    clientRestored,
+    serverRestored,
+  };
+};
+
+export const getPatchState = (
+  gameDir: string,
+  version: GameVersion,
+  targetDomain?: string,
+): {
+  supported: boolean;
+  clientPatched: boolean;
+  serverPatched: boolean;
+  clientHasBackup: boolean;
+  serverHasBackup: boolean;
+} => {
+  const supported =
+    process.platform === "win32" ||
+    process.platform === "linux" ||
+    process.platform === "darwin";
+
+  const clientPath = getClientPath(gameDir, version);
+  const serverPath = getServerPath(gameDir, version);
+  const domain = getValidDomain(targetDomain || DEFAULT_AUTH_DOMAIN);
+
+  return {
+    supported,
+    clientPatched: clientPath ? isFilePatched(clientPath, domain) : false,
+    serverPatched: serverPath ? isFilePatched(serverPath, domain) : false,
+    clientHasBackup: clientPath
+      ? fs.existsSync(clientPath + BACKUP_EXTENSION)
+      : false,
+    serverHasBackup: serverPath
+      ? fs.existsSync(serverPath + BACKUP_EXTENSION)
+      : false,
+  };
+};
+
+export const patchGameWithProgress = async (
+  gameDir: string,
+  version: GameVersion,
+  win: BrowserWindow,
+  progressChannel = "patch-progress",
+  targetDomain?: string,
+): Promise<{ success: boolean; patchCount: number; error?: string }> => {
+  const progressCallback: PatchProgress = (message, percent) => {
+    win.webContents.send(progressChannel, {
+      phase: "patching",
+      message,
+      percent: percent ?? -1,
+    });
+  };
+
+  return ensureClientPatched(gameDir, version, progressCallback, targetDomain);
+};
+
+export default {
+  ensureClientPatched,
+  restoreOriginals,
+  getPatchState,
+  patchGameWithProgress,
+  isFilePatched,
+  BACKUP_EXTENSION,
+  ORIGINAL_DOMAIN,
+};

--- a/electron/utils/game/manifest.ts
+++ b/electron/utils/game/manifest.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import type { GameVersion } from "./types";
 
 export const INSTALLED_MANIFEST_FILENAME = ".butter-installed.json";
 

--- a/electron/utils/game/onlinePatch.ts
+++ b/electron/utils/game/onlinePatch.ts
@@ -1,1275 +1,82 @@
-import fs from "fs";
-import path from "path";
-import crypto from "node:crypto";
-import stream from "node:stream";
-import { promisify } from "util";
+/**
+ * Online Patch Module - Now uses local binary patching (method by Sanasol)
+ * 
+ * The old CDN-based pre-patched binary system has been replaced with
+ * local binary patching that modifies the game executables directly.
+ */
+
 import { BrowserWindow } from "electron";
 import {
-  migrateLegacyChannelInstallIfNeeded,
-  resolveClientPath,
-  resolveExistingInstallDir,
-  resolveServerPath,
-} from "./paths";
+  ensureClientPatched,
+  restoreOriginals,
+  getPatchState,
+  patchGameWithProgress,
+} from "./binaryPatcher";
+import type { GameVersion } from "./types";
+import { URL } from "url";
 
-const pipeline = promisify(stream.pipeline);
-
-const FETCH_TIMEOUT_MS = 45_000;
-
-type AggregateProgress = {
-  total?: number;
-  current: number;
-};
-
-const PATCH_ROOT_DIRNAME = ".butter-online-patch";
-const PATCH_STATE_FILENAME = "state.json";
-
-const normalizeHash = (h: string) => h.trim().toUpperCase();
-
-const withCacheBuster = (url: string, cacheKey: string) => {
-  try {
-    const u = new URL(url);
-    u.searchParams.set("cb", cacheKey);
-    return u.toString();
-  } catch {
-    const sep = url.includes("?") ? "&" : "?";
-    return `${url}${sep}cb=${encodeURIComponent(cacheKey)}`;
-  }
-};
-
-const headContentLength = async (url: string): Promise<number | undefined> => {
-  // because servers always send content length right
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-  try {
-    const res = await fetch(url, {
-      method: "HEAD",
-      signal: controller.signal,
-    });
-    if (!res.ok) return undefined;
-    const contentLength = res.headers.get("content-length");
-    if (!contentLength) return undefined;
-    const n = parseInt(contentLength, 10);
-    return Number.isFinite(n) && n > 0 ? n : undefined;
-  } catch {
+function getDomain(authServerUrl?: string | null): string | undefined {
+    if (authServerUrl) {
+        try {
+            return new URL(authServerUrl).hostname;
+        } catch {
+            return authServerUrl;
+        }
+    }
     return undefined;
-  } finally {
-    clearTimeout(timeout);
-  }
-};
+}
 
-const sha256File = (filePath: string): Promise<string> => {
-  return new Promise((resolve, reject) => {
-    const hash = crypto.createHash("sha256");
-    const input = fs.createReadStream(filePath);
-    input.on("error", reject);
-    input.on("data", (chunk) => hash.update(chunk));
-    input.on("end", () => resolve(hash.digest("hex")));
-  });
-};
+// Re-export the new patcher functions with compatible names
 
-const getClientPath = (gameDir: string, version: GameVersion) => {
-  migrateLegacyChannelInstallIfNeeded(gameDir, version.type);
-  const installDir = resolveExistingInstallDir(gameDir, version);
-  return resolveClientPath(installDir);
-};
-
-const getPatchPaths = (clientPath: string) => {
-  const clientDir = path.dirname(clientPath);
-  const exeName = path.basename(clientPath);
-
-  const root = path.join(clientDir, PATCH_ROOT_DIRNAME);
-  const originalDir = path.join(root, "original");
-  const patchedDir = path.join(root, "patched");
-
-  const originalPath = path.join(originalDir, exeName);
-  const patchedPath = path.join(patchedDir, exeName);
-  const statePath = path.join(root, PATCH_STATE_FILENAME);
-  const tempDownloadPath = path.join(
-    root,
-    `temp_patch_download_${Date.now()}_${exeName}`,
-  );
-
-  return {
-    root,
-    originalDir,
-    patchedDir,
-    originalPath,
-    patchedPath,
-    statePath,
-    tempDownloadPath,
-  };
-};
-
-const ensureDirs = (dirs: string[]) => {
-  for (const d of dirs) {
-    if (!fs.existsSync(d)) fs.mkdirSync(d, { recursive: true });
-  }
-};
-
-const moveReplace = (from: string, to: string) => {
-  ensureDirs([path.dirname(to)]);
-
-  try {
-    if (fs.existsSync(to)) fs.unlinkSync(to);
-  } catch {
-    // ignore
-  }
-
-  try {
-    fs.renameSync(from, to);
-    return;
-  } catch {
-    // Fallback to copy+remove (cross-device / locked edge cases)
-    fs.copyFileSync(from, to);
-    try {
-      fs.unlinkSync(from);
-    } catch {
-      // ignore
-    }
-  }
-};
-
-const unlinkIfExists = (filePath: string) => {
-  try {
-    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
-  } catch {
-    // ignore
-  }
-};
-
-const copyReplace = (from: string, to: string) => {
-  ensureDirs([path.dirname(to)]);
-  unlinkIfExists(to);
-  fs.copyFileSync(from, to);
-};
-
-type PatchStateFile = {
-  enabled: boolean;
-  patch_hash?: string;
-  patch_url?: string;
-  original_url?: string;
-  patch_note?: string;
-  updatedAt: number;
-};
-
-const readPatchState = (statePath: string): PatchStateFile | null => {
-  try {
-    if (!fs.existsSync(statePath)) return null;
-    const raw = fs.readFileSync(statePath, "utf8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object") return null;
-    if (typeof parsed.enabled !== "boolean") return null;
-    return parsed as PatchStateFile;
-  } catch {
-    return null;
-  }
-};
-
-const writePatchState = (statePath: string, next: PatchStateFile) => {
-  try {
-    ensureDirs([path.dirname(statePath)]);
-    fs.writeFileSync(statePath, JSON.stringify(next, null, 2), "utf8");
-  } catch {
-    // ignore
-  }
-};
-
-const downloadFileWithProgress = async (
-  url: string,
-  outPath: string,
-  win: BrowserWindow,
-  progressChannel:
-    | "install-progress"
-    | "online-patch-progress"
-    | "online-unpatch-progress",
-  phase: "online-patch" | "online-unpatch" = "online-patch",
-  aggregate?: AggregateProgress,
-) => {
-  // one progress bar to rule them all
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
-  const response = await fetch(url, { signal: controller.signal }).finally(
-    () => {
-      clearTimeout(timeout);
-    },
-  );
-
-  if (!response.ok)
-    throw new Error(`Failed to download file (${response.status})`);
-  if (!response.body) throw new Error("No response body");
-
-  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
-  if (
-    contentType.includes("text/html") ||
-    contentType.includes("application/xhtml+xml")
-  ) {
-    let snippet = "";
-    try {
-      snippet = (await response.clone().text()).slice(0, 200);
-    } catch {
-      // ignore
-    }
-
-    throw new Error(
-      `Download returned HTML instead of a binary. This usually means a CDN cache or error page was served. URL: ${url}` +
-        (snippet ? ` (starts with: ${JSON.stringify(snippet)})` : ""),
-    );
-  }
-
-  const contentLength = response.headers.get("content-length");
-  const fileTotalLength = contentLength ? parseInt(contentLength, 10) : 0;
-  const totalLength =
-    typeof aggregate?.total === "number" && aggregate.total > 0
-      ? aggregate.total
-      : fileTotalLength;
-  let downloadedLength = 0;
-
-  const progressStream = new stream.PassThrough();
-  progressStream.on("data", (chunk) => {
-    downloadedLength += chunk.length;
-
-    if (aggregate) aggregate.current += chunk.length;
-
-    const percent =
-      totalLength > 0
-        ? Math.round(
-            ((aggregate ? aggregate.current : downloadedLength) / totalLength) *
-              100,
-          )
-        : -1;
-
-    win.webContents.send(progressChannel, {
-      phase,
-      percent,
-      total: totalLength > 0 ? totalLength : undefined,
-      current: aggregate ? aggregate.current : downloadedLength,
-    });
-  });
-
-  // Initial state (indeterminate if content-length missing)
-  win.webContents.send(progressChannel, {
-    phase,
-    percent: totalLength > 0 ? 0 : -1,
-    total: totalLength > 0 ? totalLength : undefined,
-    current: aggregate ? aggregate.current : 0,
-  });
-
-  await pipeline(
-    // @ts-expect-error - Node stream/web stream type mismatch
-    stream.Readable.fromWeb(response.body),
-    progressStream,
-    fs.createWriteStream(outPath),
-  );
-
-  const finalPercent =
-    totalLength > 0
-      ? Math.round(
-          ((aggregate ? aggregate.current : downloadedLength) / totalLength) *
-            100,
-        )
-      : -1;
-  win.webContents.send(progressChannel, {
-    phase,
-    percent: aggregate ? finalPercent : 100,
-    total: totalLength > 0 ? totalLength : undefined,
-    current: aggregate ? aggregate.current : downloadedLength,
-  });
-};
-
-// Client Patching
-
-export const getClientPatchState = (
+export const getOnlinePatchState = (
   gameDir: string,
   version: GameVersion,
+  authServerUrl?: string | null,
 ): {
   supported: boolean;
   available: boolean;
   enabled: boolean;
   downloaded: boolean;
 } => {
-  const supported =
-    process.platform === "win32" ||
-    process.platform === "linux" ||
-    process.platform === "darwin";
-  const available = !!(version.patch_url && version.patch_hash);
-  if (!supported || !available)
-    return { supported, available, enabled: false, downloaded: false };
-
-  const clientPath = getClientPath(gameDir, version);
-  if (!fs.existsSync(clientPath))
-    return { supported, available, enabled: false, downloaded: false };
-
-  const { statePath, patchedPath, originalPath } = getPatchPaths(clientPath);
-  const state = readPatchState(statePath);
-
-  // Derive current on-disk state (can drift if state.json is deleted/corrupted).
-  let clientIsPatched = false;
-  try {
-    const currentHash = crypto.createHash("sha256");
-    const input = fs.createReadStream(clientPath);
-    input.on("data", (chunk) => currentHash.update(chunk));
-    // Synchronous wrapper: getOnlinePatchState is sync, so keep it cheap if hash can't be computed.
-    // If needed, health-check uses the async sha256File path.
-    input.on("error", () => undefined);
-    // Not awaiting; treat as unknown.
-    clientIsPatched = false;
-  } catch {
-    clientIsPatched = false;
-  }
-
-  // If state says "unpatched" but the client is clearly patched and we have patch storage,
-  // treat it as patched (and heal state) to avoid false "Fix Client" and broken disable.
-  let enabled = !!state?.enabled;
-  if (!enabled && clientIsPatched && fs.existsSync(patchedPath)) {
-    enabled = true;
-    writePatchState(statePath, {
-      enabled: true,
-      patch_hash: version.patch_hash,
-      patch_url: version.patch_url,
-      original_url: version.original_url ?? state?.original_url,
-      patch_note: version.patch_note,
-      updatedAt: Date.now(),
-    });
-  }
-
-  // If state is missing, infer from disk.
-  if (!state && clientIsPatched) enabled = true;
-
-  // If we're enabled but missing backups, don't block state (disable can recover via original_url).
-  void originalPath;
-
+  const state = getPatchState(gameDir, version, getDomain(authServerUrl));
+  
   return {
-    supported,
-    available,
-    enabled,
-    downloaded: fs.existsSync(patchedPath),
+    supported: true, // Always supported with local patching
+    available: true, // Always available with local patching
+    enabled: state.clientPatched || state.serverPatched,
+    downloaded: true, // No download needed for local patching
   };
 };
 
-export const getClientPatchHealth = async (
+export const getOnlinePatchHealth = async (
   gameDir: string,
   version: GameVersion,
+  authServerUrl?: string | null,
 ): Promise<{
   supported: boolean;
   available: boolean;
   enabled: boolean;
   clientIsPatched: boolean;
+  serverIsPatched: boolean;
   needsFixClient: boolean;
+  needsFixServer: boolean;
+  needsFix: boolean;
   patchOutdated: boolean;
 }> => {
-  const supported =
-    process.platform === "win32" ||
-    process.platform === "linux" ||
-    process.platform === "darwin";
-  const available = !!(version.patch_url && version.patch_hash);
-  if (!supported || !available) {
-    return {
-      supported,
-      available,
-      enabled: false,
-      clientIsPatched: false,
-      needsFixClient: false,
-      patchOutdated: false,
-    };
-  }
-
-  const clientPath = getClientPath(gameDir, version);
-  if (!fs.existsSync(clientPath)) {
-    return {
-      supported,
-      available,
-      enabled: false,
-      clientIsPatched: false,
-      needsFixClient: false,
-      patchOutdated: false,
-    };
-  }
-
-  const { statePath, patchedPath } = getPatchPaths(clientPath);
-  const state = readPatchState(statePath);
-
-  // Start with remembered state when present.
-  let enabled = typeof state?.enabled === "boolean" ? state.enabled : false;
-
-  const detectHash = state?.patch_hash || version.patch_hash;
-  let clientIsPatched = false;
-  try {
-    const currentHash = await sha256File(clientPath);
-    clientIsPatched =
-      !!detectHash && normalizeHash(currentHash) === normalizeHash(detectHash);
-  } catch {
-    clientIsPatched = false;
-  }
-
-  // Heal drift: state says unpatched but binary is patched and we have patch storage.
-  if (!enabled && clientIsPatched && fs.existsSync(patchedPath)) {
-    enabled = true;
-    writePatchState(statePath, {
-      enabled: true,
-      patch_hash: detectHash ?? version.patch_hash,
-      patch_url: version.patch_url,
-      original_url: version.original_url ?? state?.original_url,
-      patch_note: version.patch_note,
-      updatedAt: Date.now(),
-    });
-  }
-
-  // If state is missing, infer from disk (avoid false Fix Client on restart).
-  if (!state && clientIsPatched) enabled = true;
-
-  // Show Fix Client only when the launcher explicitly remembers "unpatched" but the file is patched.
-  const needsFixClient = state?.enabled === false && clientIsPatched;
-
-  const patchOutdated =
-    !!enabled &&
-    !!state?.patch_hash &&
-    !!version.patch_hash &&
-    normalizeHash(state.patch_hash) !== normalizeHash(version.patch_hash);
-
+  const state = getPatchState(gameDir, version, getDomain(authServerUrl));
+  
   return {
-    supported,
-    available,
-    enabled,
-    clientIsPatched,
-    needsFixClient,
-    patchOutdated,
+    supported: true, // Always supported
+    available: true, // Always available
+    enabled: state.clientPatched || state.serverPatched,
+    clientIsPatched: state.clientPatched,
+    serverIsPatched: state.serverPatched,
+    needsFixClient: false,
+    needsFixServer: false,
+    needsFix: false,
+    patchOutdated: false,
   };
 };
-
-export const fixClientToUnpatched = async (
-  gameDir: string,
-  version: GameVersion,
-  win: BrowserWindow,
-  progressChannel: "online-unpatch-progress" = "online-unpatch-progress",
-): Promise<"fixed" | "not-needed" | "skipped"> => {
-  const expectedPatchHash = version.patch_hash;
-  if (!expectedPatchHash) return "skipped";
-
-  const clientPath = getClientPath(gameDir, version);
-  if (!fs.existsSync(clientPath)) return "skipped";
-
-  // Only run when current client is actually the patched binary.
-  try {
-    const currentHash = await sha256File(clientPath);
-    const isPatchedNow =
-      normalizeHash(currentHash) === normalizeHash(expectedPatchHash);
-    if (!isPatchedNow) return "not-needed";
-  } catch {
-    return "skipped";
-  }
-
-  const originalUrl = version.original_url;
-  if (!originalUrl) {
-    throw new Error("Missing original_url for this build. Cannot fix client.");
-  }
-
-  const paths = getPatchPaths(clientPath);
-  ensureDirs([paths.root, paths.originalDir, paths.patchedDir]);
-
-  // Download original exe into a temp file.
-  const tempOriginal = path.join(
-    paths.root,
-    `temp_original_${Date.now()}_${path.basename(clientPath)}`,
-  );
-  await downloadFileWithProgress(
-    withCacheBuster(originalUrl, `orig-${Date.now()}`),
-    tempOriginal,
-    win,
-    progressChannel,
-    "online-unpatch",
-  );
-
-  // Safety: don't accept a server mistake that returns the patched file.
-  const downloadedHash = await sha256File(tempOriginal);
-  if (normalizeHash(downloadedHash) === normalizeHash(expectedPatchHash)) {
-    unlinkIfExists(tempOriginal);
-    throw new Error(
-      "Original download matches patch hash; refusing to fix client.",
-    );
-  }
-
-  win.webContents.send(progressChannel, {
-    phase: "online-unpatch",
-    percent: -1,
-  });
-
-  // Swap (safe):
-  // - Move current client (patched) to temp
-  // - Persist it to patched storage (if missing)
-  // - Replace active client with downloaded original
-  const tempCurrent = path.join(
-    paths.root,
-    `temp_current_${Date.now()}_${path.basename(clientPath)}`,
-  );
-  moveReplace(clientPath, tempCurrent);
-
-  // Keep a patched copy for later enabling patch.
-  if (!fs.existsSync(paths.patchedPath)) {
-    copyReplace(tempCurrent, paths.patchedPath);
-  }
-
-  // Preserve an original backup and also activate it.
-  if (!fs.existsSync(paths.originalPath)) {
-    copyReplace(tempOriginal, paths.originalPath);
-  }
-
-  moveReplace(tempOriginal, clientPath);
-  unlinkIfExists(tempCurrent);
-
-  win.webContents.send(progressChannel, {
-    phase: "online-unpatch",
-    percent: 100,
-  });
-
-  writePatchState(paths.statePath, {
-    enabled: false,
-    patch_hash: expectedPatchHash,
-    patch_url: version.patch_url,
-    original_url: originalUrl,
-    patch_note: version.patch_note,
-    updatedAt: Date.now(),
-  });
-
-  return "fixed";
-};
-
-export const enableClientPatch = async (
-  gameDir: string,
-  version: GameVersion,
-  win: BrowserWindow,
-  progressChannel:
-    | "install-progress"
-    | "online-patch-progress" = "online-patch-progress",
-  aggregate?: AggregateProgress,
-): Promise<"enabled" | "already-enabled" | "skipped"> => {
-  const url = version.patch_url;
-  const expectedHash = version.patch_hash;
-  if (!url || !expectedHash) return "skipped";
-
-  const clientPath = getClientPath(gameDir, version);
-  if (!fs.existsSync(clientPath)) return "skipped";
-
-  const paths = getPatchPaths(clientPath);
-  ensureDirs([paths.root, paths.originalDir, paths.patchedDir]);
-
-  const existing = readPatchState(paths.statePath);
-
-  // If already enabled, only consider it "already" when the active client matches the expected hash.
-  if (existing?.enabled) {
-    try {
-      const currentHash = await sha256File(clientPath);
-      if (normalizeHash(currentHash) === normalizeHash(expectedHash))
-        return "already-enabled";
-    } catch {
-      // ignore
-    }
-    // Otherwise, proceed to (re)apply the expected patched binary.
-  }
-
-  // Ensure patched exe is downloaded into storage.
-  let patchedOk = false;
-  if (fs.existsSync(paths.patchedPath)) {
-    // Fast path: if the expected hash changed, treat cached patched exe as stale.
-    if (
-      existing?.patch_hash &&
-      normalizeHash(existing.patch_hash) !== normalizeHash(expectedHash)
-    ) {
-      patchedOk = false;
-    } else {
-      try {
-        const cachedHash = await sha256File(paths.patchedPath);
-        patchedOk = normalizeHash(cachedHash) === normalizeHash(expectedHash);
-      } catch {
-        patchedOk = false;
-      }
-    }
-  }
-
-  if (!patchedOk) {
-    try {
-      if (fs.existsSync(paths.patchedPath)) fs.unlinkSync(paths.patchedPath);
-    } catch {
-      // ignore
-    }
-
-    await downloadFileWithProgress(
-      withCacheBuster(url, `patch-${normalizeHash(expectedHash)}`),
-      paths.tempDownloadPath,
-      win,
-      progressChannel,
-      "online-patch",
-      aggregate,
-    );
-
-    const downloadedHash = await sha256File(paths.tempDownloadPath);
-    const got = normalizeHash(downloadedHash);
-    const expected = normalizeHash(expectedHash);
-    if (got !== expected) {
-      try {
-        fs.unlinkSync(paths.tempDownloadPath);
-      } catch {
-        // ignore
-      }
-      throw new Error(
-        `Patch hash mismatch (SHA256). Expected ${expected}, got ${got}.`,
-      );
-    }
-
-    moveReplace(paths.tempDownloadPath, paths.patchedPath);
-  }
-
-  // Swap (safe):
-  // - Never overwrite a preserved original backup.
-  // - Keep the downloaded patched exe on disk.
-  // - Replace the active client by moving it to a temp file, then copying patched into place.
-  win.webContents.send(progressChannel, { phase: "online-patch", percent: -1 });
-
-  // If we don't have an original backup yet, preserve the current client as original.
-  if (!fs.existsSync(paths.originalPath)) {
-    // Safety: if the current client is already patched, do NOT store it as original.
-    // This can happen if state drifted or a previous swap failed.
-    let currentIsPatched = false;
-    try {
-      const currentHash = await sha256File(clientPath);
-      currentIsPatched =
-        normalizeHash(currentHash) === normalizeHash(expectedHash);
-    } catch {
-      currentIsPatched = false;
-    }
-
-    if (currentIsPatched) {
-      const originalUrl = version.original_url || existing?.original_url;
-      if (!originalUrl) {
-        throw new Error(
-          "Cannot preserve original: client is already patched and original_url is missing.",
-        );
-      }
-
-      const tempOriginal = path.join(
-        paths.root,
-        `temp_original_${Date.now()}_${path.basename(clientPath)}`,
-      );
-      await downloadFileWithProgress(
-        withCacheBuster(originalUrl, `orig-${Date.now()}`),
-        tempOriginal,
-        win,
-        progressChannel,
-        "online-patch",
-        aggregate,
-      );
-
-      const downloadedHash = await sha256File(tempOriginal);
-      if (normalizeHash(downloadedHash) === normalizeHash(expectedHash)) {
-        unlinkIfExists(tempOriginal);
-        throw new Error(
-          "Original download matches patch hash; refusing to preserve.",
-        );
-      }
-
-      moveReplace(tempOriginal, paths.originalPath);
-    } else {
-      moveReplace(clientPath, paths.originalPath);
-    }
-  } else {
-    // Original already preserved; move current client out of the way.
-    const tempCurrent = path.join(
-      paths.root,
-      `temp_current_${Date.now()}_${path.basename(clientPath)}`,
-    );
-    moveReplace(clientPath, tempCurrent);
-    unlinkIfExists(tempCurrent);
-  }
-
-  copyReplace(paths.patchedPath, clientPath);
-  win.webContents.send(progressChannel, {
-    phase: "online-patch",
-    percent: 100,
-  });
-
-  writePatchState(paths.statePath, {
-    enabled: true,
-    patch_hash: expectedHash,
-    patch_url: url,
-    original_url: version.original_url,
-    patch_note: version.patch_note,
-    updatedAt: Date.now(),
-  });
-
-  return "enabled";
-};
-
-export const disableClientPatch = async (
-  gameDir: string,
-  version: GameVersion,
-  win: BrowserWindow,
-  progressChannel: "online-unpatch-progress" = "online-unpatch-progress",
-): Promise<"disabled" | "already-disabled" | "skipped"> => {
-  const url = version.patch_url;
-  const expectedHash = version.patch_hash;
-  if (!url || !expectedHash) return "skipped";
-
-  const clientPath = getClientPath(gameDir, version);
-  if (!fs.existsSync(clientPath)) return "skipped";
-
-  const paths = getPatchPaths(clientPath);
-  ensureDirs([paths.root, paths.originalDir, paths.patchedDir]);
-
-  const existing = readPatchState(paths.statePath);
-
-  // Trust disk reality: allow disabling if the active client matches either the current expected hash
-  // or the stored hash (when the server hash has changed since it was applied).
-  let clientIsPatched = false;
-  try {
-    const currentHash = await sha256File(clientPath);
-    const storedHash = existing?.patch_hash;
-    clientIsPatched =
-      normalizeHash(currentHash) === normalizeHash(expectedHash) ||
-      (!!storedHash &&
-        normalizeHash(currentHash) === normalizeHash(storedHash));
-  } catch {
-    clientIsPatched = false;
-  }
-
-  if (!existing?.enabled && !clientIsPatched) return "already-disabled";
-
-  if (!fs.existsSync(paths.originalPath)) {
-    const originalUrl = version.original_url || existing?.original_url;
-    if (!originalUrl) {
-      throw new Error(
-        "Original client backup not found. Reinstall the game to restore it.",
-      );
-    }
-
-    // Legacy recovery: download the original client exe into the backup slot.
-    const tempOriginal = path.join(
-      paths.root,
-      `temp_original_${Date.now()}_${path.basename(clientPath)}`,
-    );
-    await downloadFileWithProgress(
-      withCacheBuster(originalUrl, `orig-${Date.now()}`),
-      tempOriginal,
-      win,
-      progressChannel,
-      "online-unpatch",
-    );
-
-    // Safety: if server accidentally serves the patched exe, do not accept it as original.
-    try {
-      const downloadedHash = await sha256File(tempOriginal);
-      if (normalizeHash(downloadedHash) === normalizeHash(expectedHash)) {
-        unlinkIfExists(tempOriginal);
-        throw new Error(
-          "Original download matches patch hash; refusing to restore.",
-        );
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e;
-      // ignore hash failure
-    }
-
-    moveReplace(tempOriginal, paths.originalPath);
-  }
-
-  // If the preserved "original" is actually the patched exe, recover by re-downloading original_url.
-  try {
-    const originalHash = await sha256File(paths.originalPath);
-    if (normalizeHash(originalHash) === normalizeHash(expectedHash)) {
-      const originalUrl = version.original_url || existing?.original_url;
-      if (!originalUrl) {
-        throw new Error(
-          "Original backup is invalid and original_url is missing.",
-        );
-      }
-
-      const tempOriginal = path.join(
-        paths.root,
-        `temp_original_${Date.now()}_${path.basename(clientPath)}`,
-      );
-      await downloadFileWithProgress(
-        withCacheBuster(originalUrl, `orig-${Date.now()}`),
-        tempOriginal,
-        win,
-        progressChannel,
-        "online-unpatch",
-      );
-
-      const downloadedHash = await sha256File(tempOriginal);
-      if (normalizeHash(downloadedHash) === normalizeHash(expectedHash)) {
-        unlinkIfExists(tempOriginal);
-        throw new Error(
-          "Original download matches patch hash; refusing to restore.",
-        );
-      }
-
-      moveReplace(tempOriginal, paths.originalPath);
-    }
-  } catch (e) {
-    if (e instanceof Error) throw e;
-    // ignore
-  }
-
-  win.webContents.send(progressChannel, {
-    phase: "online-unpatch",
-    percent: -1,
-  });
-
-  // Swap back (safe):
-  // - Move current client (expected patched) into temp
-  // - Copy temp into patched storage (so patch stays downloaded)
-  // - Copy original backup into active client
-  const tempCurrent = path.join(
-    paths.root,
-    `temp_current_${Date.now()}_${path.basename(clientPath)}`,
-  );
-  moveReplace(clientPath, tempCurrent);
-  copyReplace(tempCurrent, paths.patchedPath);
-  copyReplace(paths.originalPath, clientPath);
-  unlinkIfExists(tempCurrent);
-
-  win.webContents.send(progressChannel, {
-    phase: "online-unpatch",
-    percent: 100,
-  });
-
-  writePatchState(paths.statePath, {
-    enabled: false,
-    patch_hash: expectedHash,
-    patch_url: url,
-    original_url: version.original_url || existing?.original_url,
-    patch_note: version.patch_note,
-    updatedAt: Date.now(),
-  });
-
-  // Final sanity: if we still look patched, surface a clear error.
-  try {
-    const afterHash = await sha256File(clientPath);
-    if (normalizeHash(afterHash) === normalizeHash(expectedHash)) {
-      throw new Error(
-        "Unpatch completed but client hash is still patched. Use Fix Client.",
-      );
-    }
-  } catch (e) {
-    if (e instanceof Error) throw e;
-  }
-
-  return "disabled";
-};
-
-export const checkClientPatchNeeded = async (
-  gameDir: string,
-  version: GameVersion,
-): Promise<"needs" | "up-to-date" | "skipped"> => {
-  const expectedHash = version.patch_hash;
-  if (!version.patch_url || !expectedHash) return "skipped";
-
-  const clientPath = getClientPath(gameDir, version);
-  if (!fs.existsSync(clientPath)) return "skipped";
-
-  try {
-    const currentHash = await sha256File(clientPath).catch(() => null);
-    if (!currentHash) return "needs";
-    if (normalizeHash(currentHash) === normalizeHash(expectedHash))
-      return "up-to-date";
-    return "needs";
-  } catch {
-    return "needs";
-  }
-};
-
-// Server Patching
-
-const getServerPath = (gameDir: string, version: GameVersion) => {
-  migrateLegacyChannelInstallIfNeeded(gameDir, version.type);
-  const installDir = resolveExistingInstallDir(gameDir, version);
-  return resolveServerPath(installDir);
-};
-
-export const getServerPatchState = (
-  gameDir: string,
-  version: GameVersion,
-): {
-  supported: boolean;
-  available: boolean;
-  enabled: boolean;
-  downloaded: boolean;
-} => {
-  const supported =
-    process.platform === "win32" ||
-    process.platform === "linux" ||
-    process.platform === "darwin";
-  const available = !!(version.server_url && version.unserver_url);
-  if (!supported || !available)
-    return { supported, available, enabled: false, downloaded: false };
-
-  const serverPath = getServerPath(gameDir, version);
-  if (!fs.existsSync(serverPath))
-    return { supported, available, enabled: false, downloaded: false };
-
-  const { statePath, patchedPath, originalPath } = getPatchPaths(serverPath);
-  const state = readPatchState(statePath);
-
-  let enabled = !!state?.enabled;
-  if (!enabled && fs.existsSync(patchedPath)) {
-    enabled = true;
-    writePatchState(statePath, {
-      enabled: true,
-      patch_hash: version.patch_hash ?? state?.patch_hash,
-      patch_url: version.server_url,
-      original_url: version.unserver_url ?? state?.original_url,
-      patch_note: state?.patch_note,
-      updatedAt: Date.now(),
-    });
-  }
-
-  void originalPath;
-
-  return {
-    supported,
-    available,
-    enabled,
-    downloaded: fs.existsSync(patchedPath),
-  };
-};
-
-export const getServerPatchHealth = async (
-  gameDir: string,
-  version: GameVersion,
-): Promise<{
-  supported: boolean;
-  available: boolean;
-  enabled: boolean;
-  serverIsPatched: boolean;
-  needsFixServer: boolean;
-}> => {
-  const supported =
-    process.platform === "win32" ||
-    process.platform === "linux" ||
-    process.platform === "darwin";
-  const available = !!(version.server_url && version.unserver_url);
-  if (!supported || !available) {
-    return {
-      supported,
-      available,
-      enabled: false,
-      serverIsPatched: false,
-      needsFixServer: false,
-    };
-  }
-
-  const serverPath = getServerPath(gameDir, version);
-  if (!fs.existsSync(serverPath)) {
-    return {
-      supported,
-      available,
-      enabled: false,
-      serverIsPatched: false,
-      needsFixServer: false,
-    };
-  }
-
-  const { statePath, patchedPath } = getPatchPaths(serverPath);
-  const state = readPatchState(statePath);
-
-  let enabled = typeof state?.enabled === "boolean" ? state.enabled : false;
-
-  // For server, we don't have a hash to verify, so we trust the state file
-  let serverIsPatched = enabled;
-  if (!enabled && fs.existsSync(patchedPath)) {
-    enabled = true;
-    serverIsPatched = true;
-    writePatchState(statePath, {
-      enabled: true,
-      patch_hash: version.patch_hash ?? state?.patch_hash,
-      patch_url: version.server_url,
-      original_url: version.unserver_url ?? state?.original_url,
-      patch_note: state?.patch_note,
-      updatedAt: Date.now(),
-    });
-  }
-
-  const needsFixServer = state?.enabled === false && serverIsPatched;
-
-  return {
-    supported,
-    available,
-    enabled,
-    serverIsPatched,
-    needsFixServer,
-  };
-};
-
-export const fixServerToUnpatched = async (
-  gameDir: string,
-  version: GameVersion,
-  win: BrowserWindow,
-  progressChannel: "online-unpatch-progress" = "online-unpatch-progress",
-): Promise<"fixed" | "not-needed" | "skipped"> => {
-  // Logic mirrors fixClientToUnpatched but for Server
-  const serverPath = getServerPath(gameDir, version);
-  if (!fs.existsSync(serverPath)) return "skipped";
-
-  // Check health to see if we actually need a fix
-  const health = await getServerPatchHealth(gameDir, version);
-  if (!health.needsFixServer) return "not-needed";
-
-  const originalUrl = version.unserver_url;
-  if (!originalUrl) {
-    throw new Error(
-      "Missing unserver_url (original) for this build. Cannot fix server.",
-    );
-  }
-
-  const paths = getPatchPaths(serverPath);
-  ensureDirs([paths.root, paths.originalDir, paths.patchedDir]);
-
-  // Download original server into a temp file
-  const tempOriginal = path.join(
-    paths.root,
-    `temp_original_fix_${Date.now()}_${path.basename(serverPath)}`,
-  );
-
-  await downloadFileWithProgress(
-    withCacheBuster(originalUrl, `orig-fix-${Date.now()}`),
-    tempOriginal,
-    win,
-    progressChannel,
-    "online-unpatch",
-  );
-
-  win.webContents.send(progressChannel, {
-    phase: "online-unpatch",
-    percent: -1,
-  });
-
-  // Swap: Move current broken/patched server to temp, put downloaded original in place
-  const tempCurrent = path.join(
-    paths.root,
-    `temp_current_broken_${Date.now()}_${path.basename(serverPath)}`,
-  );
-
-  moveReplace(serverPath, tempCurrent);
-
-  // If we don't have a patched backup, we might want to save the 'broken' one just in case,
-  // but usually 'fix' implies the current state is untrustworthy.
-  // We will prioritize preserving a known good original.
-  if (!fs.existsSync(paths.originalPath)) {
-    copyReplace(tempOriginal, paths.originalPath);
-  }
-
-  moveReplace(tempOriginal, serverPath);
-  unlinkIfExists(tempCurrent);
-
-  win.webContents.send(progressChannel, {
-    phase: "online-unpatch",
-    percent: 100,
-  });
-
-  // Force state to disabled/healthy
-  writePatchState(paths.statePath, {
-    enabled: false,
-    patch_url: version.server_url,
-    original_url: originalUrl,
-    updatedAt: Date.now(),
-  });
-
-  return "fixed";
-};
-
-export const enableServerPatch = async (
-  gameDir: string,
-  version: GameVersion,
-  win: BrowserWindow,
-  progressChannel:
-    | "install-progress"
-    | "online-patch-progress" = "online-patch-progress",
-  aggregate?: AggregateProgress,
-): Promise<"enabled" | "already-enabled" | "skipped"> => {
-  // server patch now gets to be special too
-  const url = version.server_url;
-  const originalUrl = version.unserver_url;
-  if (!url || !originalUrl) return "skipped";
-
-  const serverPath = getServerPath(gameDir, version);
-  if (!fs.existsSync(serverPath)) return "skipped";
-
-  const paths = getPatchPaths(serverPath);
-  ensureDirs([paths.root, paths.originalDir, paths.patchedDir]);
-
-  const existing = readPatchState(paths.statePath);
-
-  const expectedKey = version.patch_hash ? normalizeHash(version.patch_hash) : undefined;
-
-  if (existing?.enabled) {
-    // we trust state until we absolutely do not
-    // Only treat it as already-enabled when the expected key matches (if present).
-    if (!expectedKey) return "already-enabled";
-    if (existing.patch_hash && normalizeHash(existing.patch_hash) === expectedKey)
-      return "already-enabled";
-    // Otherwise, proceed to re-apply and refresh cached patched server.
-  }
-
-  // Download patched server if not cached (or stale)
-  let patchedOk = false;
-  if (fs.existsSync(paths.patchedPath)) {
-    if (!expectedKey) {
-      patchedOk = true;
-    } else if (!existing?.patch_hash) {
-      patchedOk = false;
-    } else {
-      patchedOk = normalizeHash(existing.patch_hash) === expectedKey;
-    }
-  }
-
-  if (!patchedOk) {
-    // cache invalidation is my favorite hobby
-    try {
-      if (fs.existsSync(paths.patchedPath)) fs.unlinkSync(paths.patchedPath);
-    } catch {
-      // ignore
-    }
-
-    await downloadFileWithProgress(
-      withCacheBuster(url, `server-patch-${expectedKey ?? Date.now().toString()}`),
-      paths.tempDownloadPath,
-      win,
-      progressChannel,
-      "online-patch",
-      aggregate,
-    );
-
-    moveReplace(paths.tempDownloadPath, paths.patchedPath);
-  }
-
-  win.webContents.send(progressChannel, { phase: "online-patch", percent: -1 });
-
-  // Preserve original if not already backed up
-  if (!fs.existsSync(paths.originalPath)) {
-    moveReplace(serverPath, paths.originalPath);
-  } else {
-    const tempCurrent = path.join(
-      paths.root,
-      `temp_current_${Date.now()}_${path.basename(serverPath)}`,
-    );
-    moveReplace(serverPath, tempCurrent);
-    unlinkIfExists(tempCurrent);
-  }
-
-  copyReplace(paths.patchedPath, serverPath);
-  win.webContents.send(progressChannel, {
-    phase: "online-patch",
-    percent: 100,
-  });
-
-  writePatchState(paths.statePath, {
-    enabled: true,
-    patch_hash: version.patch_hash,
-    patch_url: url,
-    original_url: originalUrl,
-    updatedAt: Date.now(),
-  });
-
-  return "enabled";
-};
-
-export const disableServerPatch = async (
-  gameDir: string,
-  version: GameVersion,
-  win: BrowserWindow,
-  progressChannel: "online-unpatch-progress" = "online-unpatch-progress",
-): Promise<"disabled" | "already-disabled" | "skipped"> => {
-  const url = version.server_url;
-  const originalUrl = version.unserver_url;
-  if (!url || !originalUrl) return "skipped";
-
-  const serverPath = getServerPath(gameDir, version);
-  if (!fs.existsSync(serverPath)) return "skipped";
-
-  const paths = getPatchPaths(serverPath);
-  ensureDirs([paths.root, paths.originalDir, paths.patchedDir]);
-
-  const existing = readPatchState(paths.statePath);
-
-  // Allow disable if state is missing but we have evidence of patch storage.
-  const looksPatched = !!existing?.enabled || fs.existsSync(paths.patchedPath);
-  if (!looksPatched) return "already-disabled";
-
-  if (!fs.existsSync(paths.originalPath)) {
-    // Need to download the original server
-    const tempOriginal = path.join(
-      paths.root,
-      `temp_original_${Date.now()}_${path.basename(serverPath)}`,
-    );
-    await downloadFileWithProgress(
-      withCacheBuster(originalUrl, `orig-${Date.now()}`),
-      tempOriginal,
-      win,
-      progressChannel,
-      "online-unpatch",
-    );
-
-    moveReplace(tempOriginal, paths.originalPath);
-  }
-
-  win.webContents.send(progressChannel, {
-    phase: "online-unpatch",
-    percent: -1,
-  });
-
-  // Swap back
-  const tempCurrent = path.join(
-    paths.root,
-    `temp_current_${Date.now()}_${path.basename(serverPath)}`,
-  );
-  moveReplace(serverPath, tempCurrent);
-  copyReplace(tempCurrent, paths.patchedPath);
-  copyReplace(paths.originalPath, serverPath);
-  unlinkIfExists(tempCurrent);
-
-  win.webContents.send(progressChannel, {
-    phase: "online-unpatch",
-    percent: 100,
-  });
-
-  writePatchState(paths.statePath, {
-    enabled: false,
-    patch_hash: version.patch_hash,
-    patch_url: url,
-    original_url: originalUrl,
-    updatedAt: Date.now(),
-  });
-
-  return "disabled";
-};
-
-export const checkServerPatchNeeded = async (
-  gameDir: string,
-  version: GameVersion,
-): Promise<"needs" | "up-to-date" | "skipped"> => {
-  if (!version.server_url || !version.unserver_url) return "skipped";
-
-  const serverPath = getServerPath(gameDir, version);
-  if (!fs.existsSync(serverPath)) return "skipped";
-
-  const { statePath } = getPatchPaths(serverPath);
-  const state = readPatchState(statePath);
-
-  const expectedKey = version.patch_hash ? normalizeHash(version.patch_hash) : undefined;
-
-  // If state says enabled and patch_url matches, consider up-to-date
-  if (
-    state?.enabled &&
-    state.patch_url === version.server_url &&
-    (!expectedKey ||
-      (state.patch_hash && normalizeHash(state.patch_hash) === expectedKey))
-  ) {
-    return "up-to-date";
-  }
-
-  return "needs";
-};
-
-// Unified wrappers that handle both client and server patching
 
 export const enableOnlinePatch = async (
   gameDir: string,
@@ -1278,109 +85,36 @@ export const enableOnlinePatch = async (
   progressChannel:
     | "install-progress"
     | "online-patch-progress" = "online-patch-progress",
+  authServerUrl?: string | null,
 ): Promise<"enabled" | "already-enabled" | "skipped"> => {
-  // two downloads one progress bar no regrets
-  // Preflight downloads so UI shows combined size when downloading both.
-  const wantsServer = !!(version.server_url && version.unserver_url);
-
-  const preflightClientNeedsDownload = async (): Promise<boolean> => {
-    const url = version.patch_url;
-    const expectedHash = version.patch_hash;
-    if (!url || !expectedHash) return false;
-
-    const clientPath = getClientPath(gameDir, version);
-    if (!fs.existsSync(clientPath)) return false;
-
-    const paths = getPatchPaths(clientPath);
-    const existing = readPatchState(paths.statePath);
-    if (!fs.existsSync(paths.patchedPath)) return true;
-
-    if (
-      existing?.patch_hash &&
-      normalizeHash(existing.patch_hash) !== normalizeHash(expectedHash)
-    ) {
-      return true;
-    }
-
-    try {
-      const cachedHash = await sha256File(paths.patchedPath);
-      return normalizeHash(cachedHash) !== normalizeHash(expectedHash);
-    } catch {
-      return true;
-    }
-  };
-
-  const preflightServerNeedsDownload = async (): Promise<boolean> => {
-    if (!wantsServer) return false;
-
-    const serverPath = getServerPath(gameDir, version);
-    if (!fs.existsSync(serverPath)) return false;
-
-    const paths = getPatchPaths(serverPath);
-    const existing = readPatchState(paths.statePath);
-    if (!fs.existsSync(paths.patchedPath)) return true;
-
-    const expectedKey = version.patch_hash
-      ? normalizeHash(version.patch_hash)
-      : undefined;
-
-    // If we have a client patch hash, require server state to match it.
-    if (expectedKey) {
-      if (!existing?.patch_hash) return true;
-      if (normalizeHash(existing.patch_hash) !== expectedKey) return true;
-    }
-
-    return false;
-  };
-
-  const needsClientDownload = await preflightClientNeedsDownload();
-  const needsServerDownload = await preflightServerNeedsDownload();
-
-  let aggregate: AggregateProgress | undefined;
-  if (needsClientDownload || needsServerDownload) {
-    // asking the internet how big the internet is
-    const sizes = await Promise.all([
-      needsClientDownload && version.patch_url
-        ? headContentLength(withCacheBuster(version.patch_url, "patch-head"))
-        : Promise.resolve(undefined),
-      needsServerDownload && version.server_url
-        ? headContentLength(withCacheBuster(version.server_url, "server-head"))
-        : Promise.resolve(undefined),
-    ]);
-
-    const required: Array<number | undefined> = [];
-    if (needsClientDownload) required.push(sizes[0]);
-    if (needsServerDownload) required.push(sizes[1]);
-
-    let allKnown = true;
-    let total = 0;
-    for (const n of required) {
-      if (typeof n !== "number" || !(n > 0)) {
-        allKnown = false;
-        continue;
-      }
-      total += n;
-    }
-
-    // if sizes are unknown we pretend everything is fine
-    aggregate = { total: allKnown && total > 0 ? total : undefined, current: 0 };
+  const domain = getDomain(authServerUrl);
+  const state = getPatchState(gameDir, version, domain);
+  
+  if (!state.supported) return "skipped";
+  
+  if (state.clientPatched && state.serverPatched) {
+    return "already-enabled";
   }
 
-  // First, patch the client
-  const clientResult = await enableClientPatch(
-    gameDir,
-    version,
-    win,
-    progressChannel,
-    aggregate,
-  );
+  const progressCallback = (message: string, percent: number | null) => {
+    win.webContents.send(progressChannel, {
+      phase: "online-patch",
+      message,
+      percent: percent ?? -1,
+    });
+  };
 
-  // Then, patch the server if available
-  if (wantsServer) {
-    await enableServerPatch(gameDir, version, win, progressChannel, aggregate);
+  const result = await ensureClientPatched(gameDir, version, progressCallback, domain);
+  
+  if (result.success) {
+    win.webContents.send(progressChannel, {
+      phase: "online-patch",
+      percent: 100,
+    });
+    return "enabled";
   }
-
-  return clientResult;
+  
+  return "skipped";
 };
 
 export const disableOnlinePatch = async (
@@ -1388,131 +122,99 @@ export const disableOnlinePatch = async (
   version: GameVersion,
   win: BrowserWindow,
   progressChannel: "online-unpatch-progress" = "online-unpatch-progress",
+  authServerUrl?: string | null,
 ): Promise<"disabled" | "already-disabled" | "skipped"> => {
-  // First, unpatch the client
-  const clientResult = await disableClientPatch(
-    gameDir,
-    version,
-    win,
-    progressChannel,
-  );
-
-  // Then, unpatch the server if available
-  if (version.server_url && version.unserver_url) {
-    await disableServerPatch(gameDir, version, win, progressChannel);
+  const domain = getDomain(authServerUrl);
+  const state = getPatchState(gameDir, version, domain);
+  
+  if (!state.supported) return "skipped";
+  
+  if (!state.clientPatched && !state.serverPatched) {
+    return "already-disabled";
   }
 
-  return clientResult;
-};
-
-export const getOnlinePatchState = (
-  gameDir: string,
-  version: GameVersion,
-): {
-  supported: boolean;
-  available: boolean;
-  enabled: boolean;
-  downloaded: boolean;
-} => {
-  const clientState = getClientPatchState(gameDir, version);
-  // const serverState = getServerPatchState(gameDir, version);
-
-  // Unified State Logic:
-  // - Available: If client patch is available, the feature is available.
-  // - Enabled: True if client is enabled (server usually follows client).
-  // - Downloaded: True if client is downloaded.
-
-  return {
-    supported: clientState.supported,
-    available: clientState.available,
-    enabled: clientState.enabled,
-    downloaded: clientState.downloaded,
+  const progressCallback = (message: string, percent: number | null) => {
+    win.webContents.send(progressChannel, {
+      phase: "online-unpatch",
+      message,
+      percent: percent ?? -1,
+    });
   };
-};
 
-export const getOnlinePatchHealth = async (
-  gameDir: string,
-  version: GameVersion,
-): Promise<{
-  supported: boolean;
-  available: boolean;
-  enabled: boolean;
-  clientIsPatched: boolean;
-  serverIsPatched: boolean;
-  needsFixClient: boolean;
-  needsFixServer: boolean;
-  needsFix: boolean; // Aggregated flag
-  patchOutdated: boolean;
-}> => {
-  const clientHealth = await getClientPatchHealth(gameDir, version);
-  const serverHealth = await getServerPatchHealth(gameDir, version);
-
-  return {
-    supported: clientHealth.supported,
-    available: clientHealth.available,
-    enabled: clientHealth.enabled,
-
-    // Detailed props
-    clientIsPatched: clientHealth.clientIsPatched,
-    serverIsPatched: serverHealth.serverIsPatched,
-    needsFixClient: clientHealth.needsFixClient,
-    needsFixServer: serverHealth.needsFixServer,
-
-    // Aggregates
-    needsFix: clientHealth.needsFixClient || serverHealth.needsFixServer,
-    patchOutdated: clientHealth.patchOutdated, // Server doesn't usually report outdated hash
-  };
+  const result = await restoreOriginals(gameDir, version, progressCallback);
+  
+  if (result.success) {
+    win.webContents.send(progressChannel, {
+      phase: "online-unpatch",
+      percent: 100,
+    });
+    return "disabled";
+  }
+  
+  return "skipped";
 };
 
 export const checkOnlinePatchNeeded = async (
   gameDir: string,
   version: GameVersion,
+  authServerUrl?: string | null,
 ): Promise<"needs" | "up-to-date" | "skipped"> => {
-  const clientCheck = await checkClientPatchNeeded(gameDir, version);
-
-  // If client needs update or is skipped, that's the primary signal
-  if (clientCheck === "needs") return "needs";
-  if (clientCheck === "skipped") return "skipped";
-
-  // If client is up-to-date, we must check the server just in case
-  const serverCheck = await checkServerPatchNeeded(gameDir, version);
-
-  if (serverCheck === "needs") return "needs";
-
-  return "up-to-date";
+  const state = getPatchState(gameDir, version, getDomain(authServerUrl));
+  
+  if (!state.supported) return "skipped";
+  
+  if (state.clientPatched) {
+    return "up-to-date";
+  }
+  
+  return "needs";
 };
 
 export const fixOnlinePatch = async (
   gameDir: string,
   version: GameVersion,
   win: BrowserWindow,
-  progressChannel: "online-unpatch-progress" = "online-unpatch-progress",
+  progressChannel:
+    | "install-progress"
+    | "online-patch-progress" = "online-patch-progress",
+  authServerUrl?: string | null,
 ): Promise<"fixed" | "not-needed" | "skipped"> => {
-  // 1. Fix Client
-  const clientResult = await fixClientToUnpatched(
-    gameDir,
-    version,
-    win,
-    progressChannel,
-  );
-
-  // 2. Fix Server
-  // Note: We ignore the return value of server fix unless client was "not-needed",
-  // effectively OR-ing the results.
-  const serverResult = await fixServerToUnpatched(
-    gameDir,
-    version,
-    win,
-    progressChannel,
-  );
-
-  if (clientResult === "fixed" || serverResult === "fixed") {
-    return "fixed";
+  const domain = getDomain(authServerUrl);
+  const state = getPatchState(gameDir, version, domain);
+  
+  if (!state.supported) return "skipped";
+  
+  // If already properly patched, nothing to fix
+  if (state.clientPatched) {
+    return "not-needed";
   }
+  
+  // Re-patch
+  const progressCallback = (message: string, percent: number | null) => {
+    win.webContents.send(progressChannel, {
+      phase: "online-patch",
+      message,
+      percent: percent ?? -1,
+    });
+  };
 
-  if (clientResult === "skipped" && serverResult === "skipped") {
-    return "skipped";
-  }
-
-  return "not-needed";
+  const result = await ensureClientPatched(gameDir, version, progressCallback, domain);
+  
+  return result.success ? "fixed" : "skipped";
 };
+
+// Legacy exports for backwards compatibility
+export const getClientPatchState = getOnlinePatchState;
+export const getClientPatchHealth = getOnlinePatchHealth;
+export const enableClientPatch = enableOnlinePatch;
+export const disableClientPatch = disableOnlinePatch;
+export const checkClientPatchNeeded = checkOnlinePatchNeeded;
+export const fixClientToUnpatched = fixOnlinePatch;
+
+// Server patch functions now just delegate to the unified functions
+export const getServerPatchState = getOnlinePatchState;
+export const getServerPatchHealth = getOnlinePatchHealth;
+export const enableServerPatch = enableOnlinePatch;
+export const disableServerPatch = disableOnlinePatch;
+export const checkServerPatchNeeded = checkOnlinePatchNeeded;
+export const fixServerToUnpatched = fixOnlinePatch;

--- a/electron/utils/game/paths.ts
+++ b/electron/utils/game/paths.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { INSTALLED_MANIFEST_FILENAME, readInstallManifest, writeInstallManifest } from "./manifest";
+import type { GameVersion } from "./types";
 
 const BUILD_DIR_PREFIX = "build-";
 

--- a/electron/utils/game/types.ts
+++ b/electron/utils/game/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared type definitions for game utilities
+ */
+
+export type GameVersion = {
+  type: "release" | "pre-release";
+  build_index: number;
+  build_name?: string;
+  isLatest?: boolean;
+};
+
+export type PatchResult = {
+  success: boolean;
+  patchCount: number;
+  alreadyPatched?: boolean;
+  error?: string;
+};
+
+export type PatchProgress = (message: string, percent: number | null) => void;
+
+export type PatchState = {
+  supported: boolean;
+  clientPatched: boolean;
+  serverPatched: boolean;
+  clientHasBackup: boolean;
+  serverHasBackup: boolean;
+};
+
+export type OnlinePatchState = {
+  supported: boolean;
+  available: boolean;
+  enabled: boolean;
+  downloaded: boolean;
+};
+
+export type OnlinePatchHealth = {
+  supported: boolean;
+  available: boolean;
+  enabled: boolean;
+  clientIsPatched: boolean;
+  serverIsPatched: boolean;
+  needsFixClient: boolean;
+  needsFixServer: boolean;
+  needsFix: boolean;
+  patchOutdated: boolean;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@kostya-main/discord-rpc": "^1.2.1",
+        "adm-zip": "^0.5.16",
         "electron-updater": "^6.7.3",
         "extract-zip": "^2.0.1",
         "react": "^18.2.0",
@@ -20,6 +21,7 @@
       "devDependencies": {
         "@tabler/icons-react": "^3.36.1",
         "@tailwindcss/vite": "^4.1.18",
+        "@types/adm-zip": "^0.5.7",
         "@types/discord-rpc": "^4.0.10",
         "@types/react": "^18.2.64",
         "@types/react-dom": "^18.2.21",
@@ -2006,6 +2008,16 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.7.tgz",
+      "integrity": "sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "dev": true,
@@ -2642,6 +2654,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@kostya-main/discord-rpc": "^1.2.1",
+    "adm-zip": "^0.5.16",
     "electron-updater": "^6.7.3",
     "extract-zip": "^2.0.1",
     "react": "^18.2.0",
@@ -29,6 +30,7 @@
   "devDependencies": {
     "@tabler/icons-react": "^3.36.1",
     "@tailwindcss/vite": "^4.1.18",
+    "@types/adm-zip": "^0.5.7",
     "@types/discord-rpc": "^4.0.10",
     "@types/react": "^18.2.64",
     "@types/react-dom": "^18.2.21",

--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -81,11 +81,9 @@ const Launcher: React.FC<{ onLogout?: () => void }> = ({ onLogout }) => {
     ? selected.build_name?.trim() || `Build-${selected.build_index}`
     : "";
 
-  const patchAvailable =
-    !!selected &&
-    !!selected.installed &&
-    !!selected.patch_url &&
-    !!selected.patch_hash;
+  // CHANGED: Local binary patching is always available for installed versions
+  // No longer requires patch_url or patch_hash from remote manifest
+  const patchAvailable = !!selected && !!selected.installed;
 
   // async state updates are fun until they are not
   // we only trust the most recent health check because time is not a deterministic function
@@ -103,10 +101,13 @@ const Launcher: React.FC<{ onLogout?: () => void }> = ({ onLogout }) => {
     }
 
     try {
+      const authServerUrl = (localStorage.getItem("authServerUrl") || "").trim();
+      const authServerUrlArg = authServerUrl.length ? authServerUrl : null;
       const health = (await window.ipcRenderer.invoke(
         "online-patch:health",
         gameDir,
         selected,
+        authServerUrlArg,
       )) as {
         enabled?: boolean;
         needsFixClient?: boolean;
@@ -238,17 +239,23 @@ const Launcher: React.FC<{ onLogout?: () => void }> = ({ onLogout }) => {
 
   const startOnlinePatch = () => {
     if (!gameDir || !selected) return;
-    window.ipcRenderer.send("online-patch:enable", gameDir, selected);
+    const authServerUrl = (localStorage.getItem("authServerUrl") || "").trim();
+    const authServerUrlArg = authServerUrl.length ? authServerUrl : null;
+    window.ipcRenderer.send("online-patch:enable", gameDir, selected, authServerUrlArg);
   };
 
   const disableOnlinePatch = () => {
     if (!gameDir || !selected) return;
-    window.ipcRenderer.send("online-patch:disable", gameDir, selected);
+    const authServerUrl = (localStorage.getItem("authServerUrl") || "").trim();
+    const authServerUrlArg = authServerUrl.length ? authServerUrl : null;
+    window.ipcRenderer.send("online-patch:disable", gameDir, selected, authServerUrlArg);
   };
 
   const fixClient = () => {
     if (!gameDir || !selected) return;
-    window.ipcRenderer.send("online-patch:fix-client", gameDir, selected);
+    const authServerUrl = (localStorage.getItem("authServerUrl") || "").trim();
+    const authServerUrlArg = authServerUrl.length ? authServerUrl : null;
+    window.ipcRenderer.send("online-patch:fix-client", gameDir, selected, authServerUrlArg);
   };
 
   const deleteVersion = async (v: GameVersion) => {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -10,6 +10,7 @@ const SettingsModal: React.FC<{
 }> = ({ open, onClose, onLogout }) => {
   const { gameDir, checkForUpdates, checkingUpdates } = useGameContext();
   const [customUUID, setCustomUUID] = useState<string>("");
+  const [authServerUrl, setAuthServerUrl] = useState<string>("");
   const [enableRPC, setEnableRPC] = useState<boolean>(false);
 
   const [closing, setClosing] = useState(false);
@@ -59,6 +60,8 @@ const SettingsModal: React.FC<{
     if (!open) return;
     const storedUUID = localStorage.getItem("customUUID") || "";
     setCustomUUID(storedUUID);
+    const storedAuthServer = localStorage.getItem("authServerUrl") || "";
+    setAuthServerUrl(storedAuthServer);
     const storedRPC = localStorage.getItem("enableRPC") || "false";
     setEnableRPC(storedRPC === "true");
   }, [open]);
@@ -75,6 +78,16 @@ const SettingsModal: React.FC<{
       localStorage.setItem("customUUID", normalizedUUID);
     }
   }, [customUUID, normalizedUUID, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const raw = authServerUrl.trim();
+    if (!raw) {
+      localStorage.removeItem("authServerUrl");
+      return;
+    }
+    localStorage.setItem("authServerUrl", raw);
+  }, [authServerUrl, open]);
 
   useEffect(() => {
     if (enableRPC) {
@@ -194,6 +207,22 @@ const SettingsModal: React.FC<{
               </div>
             </div>
 
+            <div className="col-span-2 space-y-2">
+              <label className="text-xs uppercase tracking-widest text-gray-400">
+                Authentication Server
+              </label>
+              <input
+                value={authServerUrl}
+                onChange={(e) => setAuthServerUrl(e.target.value)}
+                placeholder="https://auth.sanasol.ws"
+                className="w-full px-3 py-2 rounded-lg bg-[#1f2538] text-white border border-[#2a3146] focus:outline-none focus:border-blue-500 transition"
+                spellCheck={false}
+                autoCapitalize="none"
+                autoCorrect="off"
+                inputMode="url"
+              />
+            </div>
+
             <label className="w-fit flex gap-2 items-center text-xs uppercase tracking-widest text-gray-400">
               <p>Discord RPC:</p>
               <input
@@ -229,7 +258,7 @@ const SettingsModal: React.FC<{
             </span>
             <div className="mt-1 space-y-0.5">
               <p className="text-xs text-gray-400">
-                Online Fix: <span className="text-blue-400">vZyle</span>
+                Online Fix: Created by <span className="text-blue-400">sanasol</span> implemented by <span className="text-blue-400">Gustakir</span>
               </p>
               <p className="text-xs text-gray-400">
                 System Launcher: <span className="text-blue-400">Fitzxel</span>

--- a/src/hooks/gameContext.tsx
+++ b/src/hooks/gameContext.tsx
@@ -198,12 +198,16 @@ export const GameContextProvider = ({
       const customUUID = (localStorage.getItem("customUUID") || "").trim();
       const uuidArg = customUUID.length ? customUUID : null;
 
+      const authServerUrl = (localStorage.getItem("authServerUrl") || "").trim();
+      const authServerUrlArg = authServerUrl.length ? authServerUrl : null;
+
       window.ipcRenderer.send(
         "launch-game",
         gameDir,
         version,
         username,
         uuidArg,
+        authServerUrlArg,
       );
     },
     [gameDir],

--- a/src/utils/game.ts
+++ b/src/utils/game.ts
@@ -212,18 +212,6 @@ export const getGameVersions = async (versionType: VersionType = "release") => {
         ? listedName
         : `Build-${buildIndex}`;
 
-    const patch_url =
-      typeof (detailsEntry as any)?.url === "string"
-        ? (detailsEntry as any).url
-        : undefined;
-    const original_url =
-      typeof (detailsEntry as any)?.original === "string"
-        ? (detailsEntry as any).original
-        : undefined;
-    const patch_hash =
-      typeof (detailsEntry as any)?.hash === "string"
-        ? (detailsEntry as any).hash
-        : undefined;
     const proper_patch =
       typeof (detailsEntry as any)?.proper_patch === "boolean"
         ? (detailsEntry as any).proper_patch
@@ -232,14 +220,13 @@ export const getGameVersions = async (versionType: VersionType = "release") => {
       typeof (detailsEntry as any)?.patch_note === "string"
         ? (detailsEntry as any).patch_note
         : undefined;
-    // because schema stability is a myth
+    // Server URLs still used for reference but patching is done locally
     const server_url =
       typeof (versionEntry as any)?.server_url === "string"
         ? (versionEntry as any).server_url
         : typeof (versionEntry as any)?.server === "string"
           ? (versionEntry as any).server
           : undefined;
-    // surely nobody will rename fields again
     const unserver_url =
       typeof (versionEntry as any)?.unserver_url === "string"
         ? (versionEntry as any).unserver_url
@@ -253,13 +240,10 @@ export const getGameVersions = async (versionType: VersionType = "release") => {
       build_index: buildIndex,
       build_name,
       isLatest: false,
-      patch_url: patch_url && patch_hash ? patch_url : undefined,
-      patch_hash: patch_url && patch_hash ? patch_hash : undefined,
-      original_url: patch_url && patch_hash ? original_url : undefined,
-      patch_note: patch_url && patch_hash ? patch_note : undefined,
-      proper_patch: patch_url && patch_hash ? proper_patch : undefined,
-      server_url: server_url,
-      unserver_url: unserver_url,
+      patch_note,
+      proper_patch,
+      server_url,
+      unserver_url,
     };
     return version;
   });

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -12,15 +12,11 @@ type GameVersion = {
   build_index: number;
   build_name: string;
   isLatest?: boolean;
-  patch_url?: string;
-  patch_hash?: string;
-  original_url?: string;
   patch_note?: string;
   /**
-   * When the online patch is enabled:
-   * - proper_patch === true  => launch stays offline
-   * - proper_patch === false => launch uses authenticated mode + tokens
-   * If missing, launcher falls back to legacy behavior (Linux/macOS authenticated).
+   * When proper_patch is true, the game uses offline mode.
+   * When false or missing, the game uses authenticated mode with tokens.
+   * Note: Patching is now done locally via binary modification.
    */
   proper_patch?: boolean;
   installed?: boolean;


### PR DESCRIPTION
Replace online patching with local binary patching This commit replaces the old CDN-based pre-patched binary system with a new local binary patching method. This new system, inspired by Sanasol's work, modifies the game executables directly on the user's machine.

Key changes include:

Introduction of a new binaryPatcher.ts module to handle the patching logic. Removal of the old online patching system that relied on downloading pre-patched files. The onlinePatch.ts module has been updated to use the new binary patcher, while maintaining backward compatibility with existing function names. Added adm-zip dependency for handling zip archives required for the new patching process. Updated various components like Launcher.tsx and SettingsModal.tsx to accommodate the new patching system.

This change improves the robustness and reliability of the patching process, as well as compatibility with different launchers (aka Hytale F2P), new settings to change the authentication server as well as enables multiplayer support for local worlds without needing to create servers.